### PR TITLE
Change ExpandedTermDefinition to have Keyword keys

### DIFF
--- a/src/JSONLD/Types.hs
+++ b/src/JSONLD/Types.hs
@@ -11,7 +11,7 @@ module JSONLD.Types
   , mkCompactIRI
 
     -- ** Keyword
-  , Keyword
+  , Keyword (..)
   , fromText
 
     -- ** Expanded Term Definition
@@ -43,7 +43,7 @@ data TermDefinition
   | TDExpanded ExpandedTermDefinition
   deriving stock (Show, Ord, Eq)
 
-newtype ExpandedTermDefinition = ExpandedTermDefinition (Map Term Text)
+newtype ExpandedTermDefinition = ExpandedTermDefinition (Map Keyword Text)
   deriving newtype (Eq, Ord, Show)
 
 data EDTParseError


### PR DESCRIPTION
The JSON-LD expansion algorithm has keywords like "`@container`" being looked up from this context. I can't see any normal terms.

So it seems like keys should always be keywords:

> An expanded term definition MUST be a map composed of zero or more
> keys from `@id`, `@reverse`, `@type`, `@language`, `@container`, `@context`,
> `@prefix`, `@propagate`, or `@protected`. An expanded term definition SHOULD
> NOT contain any other keys.

There are different rules for each of those keys so ideally this wouldn't even be a Map but instead something more structured (e.g. "`@id`" can be null or a IRI but "`@nest`" must only have a "`@nest`" value)